### PR TITLE
Compile HLS from source

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -6,7 +6,7 @@ jobs:
       matrix:
         include:
           - { ghc: 9.0.2, hls: 1.7.0.0 }
-          - { ghc: 9.2.4, hls: '' }
+          - { ghc: 9.2.4, hls: 7760340e999693d07fdbea49c9e20a3dd5458ad3 }
           - { ghc: 9.4.2, hls: '' }
     name: Docker with GHC ${{ matrix.ghc }}
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -3,11 +3,12 @@ on: push
 jobs:
   docker:
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - { ghc: 9.0.2, hls: 1.7.0.0 }
-          - { ghc: 9.2.4, hls: 7760340e999693d07fdbea49c9e20a3dd5458ad3 }
-          - { ghc: 9.4.2, hls: '' }
+          - { ghc: 9.0.2, hls: 830596ee212d4f2fbbc81bcf5d08574ae96947d3 }
+          - { ghc: 9.2.4, hls: 830596ee212d4f2fbbc81bcf5d08574ae96947d3 }
+          - { ghc: 9.4.2, hls: 830596ee212d4f2fbbc81bcf5d08574ae96947d3 }
     name: Docker with GHC ${{ matrix.ghc }}
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,8 +89,8 @@ ARG HLS_VERSION=1.7.0.0
 RUN \
   set -o errexit -o xtrace; \
   if test -n "$HLS_VERSION"; then \
-  ghcup install hls "$HLS_VERSION" --set; \
-  ghcup gc --hls-no-ghc; \
+  ghcup compile hls --cabal-update --ghc "$GHC_VERSION" --git-ref "$HLS_VERSION"; \
+  rm --recursive /cabal-store/* ~/.cabal/logs ~/.cabal/packages; \
   haskell-language-server-wrapper --version; \
   fi
 


### PR DESCRIPTION
This is an alternative to #7. 

I'm curious to see how long it takes in CI. On my machine (M1 MacMini) it takes about 10 minutes to build for GHC 9.2.4. 

Also it looks like maybe some support for GHC 9.4 landed recently? https://github.com/haskell/haskell-language-server/pull/2994