### PR TITLE
Use public registry alias

### DIFF
--- a/aws/image.yaml
+++ b/aws/image.yaml
@@ -12,7 +12,7 @@ phases:
 
       - echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
 
-      - server=public.ecr.aws/v6m6o3k4
+      - server=public.ecr.aws/acilearning
 
       - aws ecr-public get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$server"
 

--- a/aws/manifest.yaml
+++ b/aws/manifest.yaml
@@ -7,7 +7,7 @@ phases:
   build:
     commands:
 
-      - server=public.ecr.aws/v6m6o3k4
+      - server=public.ecr.aws/acilearning
 
       - aws ecr-public get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$server"
 


### PR DESCRIPTION
Before: https://gallery.ecr.aws/v6m6o3k4/haskell
After: https://gallery.ecr.aws/acilearning/haskell

---

- [ ] I manually tested the code locally to make sure that it works.
- [ ] If there is documentation, I made sure it's accurate and up to date.
- [ ] If possible, I wrote automated tests for the new behavior.
