### PR TITLE
chore: [sc-129896] Upgrade Smurf to GHC 9.2

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -9,7 +9,7 @@ jobs:
           - arm64
         ghc:
           - 9.0.2
-          - 9.2.4
+          - 9.2.5
           - 9.4.2
     runs-on: ubuntu-latest
     steps:
@@ -34,7 +34,7 @@ jobs:
       matrix:
         ghc:
           - 9.0.2
-          - 9.2.4
+          - 9.2.5
           - 9.4.2
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ ARG HLS_VERSION=1.8.0.0
 RUN \
   set -o errexit -o xtrace; \
   if test -n "$HLS_VERSION" && "$GHC_VERSION" == "9.2.5"; then \
-  ghcup compile hls -g 5d56aa70a84807d7659e72eacd4d91fee08dbdbb --ghc $GHC_VERSION --cabal-update --set; \
+  ghcup compile hls -g 5d56aa70a84807d7659e72eacd4d91fee08dbdbb --git-describe-version --ghc $GHC_VERSION --cabal-update --set; \
   ghcup gc --hls-no-ghc; \
   haskell-language-server-wrapper --version; \
   fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN \
   set -o errexit -o xtrace; \
   if test -n "$HLS_VERSION"; then \
   ghcup install hls "$HLS_VERSION" --set; \
-  ghcup compile hls -j -g 5d56aa70a84807d7659e72eacd4d91fee08dbdbb --ghc $GHC_VERSION --cabal-update --set \
+  ghcup compile hls -g 5d56aa70a84807d7659e72eacd4d91fee08dbdbb --ghc $GHC_VERSION --cabal-update --set \
   ghcup gc --hls-no-ghc; \
   haskell-language-server-wrapper --version; \
   fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN \
   set -o errexit -o xtrace; \
   if test -n "$HLS_VERSION"; then \
   ghcup install hls "$HLS_VERSION" --set; \
-  ghcup compile hls -g 5d56aa70a84807d7659e72eacd4d91fee08dbdbb --ghc $GHC_VERSION --cabal-update --set \
+  ghcup compile hls -g 5d56aa70a84807d7659e72eacd4d91fee08dbdbb --ghc $GHC_VERSION --cabal-update --set; \
   ghcup gc --hls-no-ghc; \
   haskell-language-server-wrapper --version; \
   fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,7 @@ RUN \
   set -o errexit -o xtrace; \
   if test -n "$HLS_VERSION"; then \
   ghcup install hls "$HLS_VERSION" --set; \
+  ghcup compile hls -j -g 5d56aa70a84807d7659e72eacd4d91fee08dbdbb --ghc $GHC_VERSION --cabal-update --set \
   ghcup gc --hls-no-ghc; \
   haskell-language-server-wrapper --version; \
   fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,8 +88,7 @@ RUN \
 ARG HLS_VERSION=1.8.0.0
 RUN \
   set -o errexit -o xtrace; \
-  if test -n "$HLS_VERSION"; then \
-  ghcup install hls "$HLS_VERSION" --set; \
+  if test -n "$HLS_VERSION" && "$GHC_VERSION" == "9.2.5"; then \
   ghcup compile hls -g 5d56aa70a84807d7659e72eacd4d91fee08dbdbb --ghc $GHC_VERSION --cabal-update --set; \
   ghcup gc --hls-no-ghc; \
   haskell-language-server-wrapper --version; \

--- a/aws/image.yaml
+++ b/aws/image.yaml
@@ -5,7 +5,7 @@ env:
     DOCKER_USERNAME: docker-hub-read-only:DOCKER_USERNAME
   variables:
     AWS_REGION: us-east-1
-    GHC_VERSION: 9.2.4
+    GHC_VERSION: 9.2.5
 phases:
   build:
     commands:

--- a/aws/manifest.yaml
+++ b/aws/manifest.yaml
@@ -2,7 +2,7 @@ version: 0.2
 env:
   variables:
     AWS_REGION: us-east-1
-    GHC_VERSION: 9.2.4
+    GHC_VERSION: 9.2.5
 phases:
   build:
     commands:


### PR DESCRIPTION
Story details: https://app.shortcut.com/itprotv/story/129896

I found that hls didn't work with ghc 9.2.4 because of what looks like an ABI error:

```
clang: error: no such file or directory: '/home/haskell/.cache/hie-bios/dist-smurf-a918fb5fb0f5015a988835da60f0159d/build/aarch64-linux/ghc-9.2.4/recurly-0.0.0.1/noopt/build/Recurly/V3/API/Types/Coupon/Name.dyn_o'
`clang' failed in phase `Linker'. (Exit code: 1)
```

It just so happens that ghc 9.2.5 release notes has some potentially related items in the changelog:

```
***** Improve determinism by not inclusing build directories in interface files (#22162).

***** Fix a code generation bug with the native code generator on aarch64 darwin leading to runtime segmentation faults due to an incorrect ABI (#21964)
```

hls doesn't support 9.2.5 in it's 1.8.0.0 release, but compiling from source as this PR does should (still waiting to test).

Would close #12 

---

- [ ] I manually tested the code locally to make sure that it works.
- [ ] If there is documentation, I made sure it's accurate and up to date.
- [ ] If possible, I wrote automated tests for the new behavior.
