### PR TITLE
Avoid hard-coding Cabal store path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,7 @@ RUN \
       ghcup install hls "$HLS_VERSION" --set; \
     fi; \
     ghcup gc --cache --hls-no-ghc --tmpdirs; \
-    rm --force --recursive --verbose /cabal-store/* ~/.cabal/{logs,packages,store}; \
+    rm --force --recursive --verbose "$CABAL_STORE/*" ~/.cabal/{logs,packages,store}; \
     haskell-language-server-wrapper --version; \
   fi
 


### PR DESCRIPTION
I should have done this in 9e6f4e3e4bc082c549f3493c4e29d2d0c8afe035 as part of #16. 

---

- [ ] I manually tested the code locally to make sure that it works.
- [ ] If there is documentation, I made sure it's accurate and up to date.
- [ ] If possible, I wrote automated tests for the new behavior.
