### PR TITLE
Add GHC 9.6.1

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -12,6 +12,8 @@ jobs:
           - { arch: arm64, ghc: 9.2.6, hls: 1.9.1.0 }
           - { arch: amd64, ghc: 9.4.4, hls: 1.9.1.0 }
           - { arch: arm64, ghc: 9.4.4, hls: 1.9.1.0 }
+          - { arch: amd64, ghc: 9.6.1, hls: '' }
+          - { arch: arm64, ghc: 9.6.1, hls: '' }
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
Fixes #31.

There's no HLS release yet. I don't know when to expect one. 