### PR TITLE
Install `pkg-config`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN \
     liblzma-dev \
     libnuma-dev \
     libpq-dev \
-    libtinfo-dev; \
+    libtinfo-dev \
+    pkg-config; \
   rm --recursive --verbose /var/lib/apt/lists/*
 
 # Configure user.


### PR DESCRIPTION
This appears to be required in order to install the `lzma` package with GHC 9.6. Without it, I see this error:

```
[__5] trying: lzma-0.0.1.0 (dependency of file-embed-lzma)
[__6] rejecting: lzma:+pkgconfig (conflict: pkg-config package liblzma>=5.2.2,
not found in the pkg-config database)
[__6] rejecting: lzma:-pkgconfig (manual flag can only be changed explicitly)
[__6] fail (backjumping, conflict set: lzma, lzma:pkgconfig)
```

---

- [x] I manually tested the code locally to make sure that it works.
- [x] If there is documentation, I made sure it's accurate and up to date.
- [x] If possible, I wrote automated tests for the new behavior.
