### PR TITLE
Upgrade to GHC 9.8.1

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -9,9 +9,11 @@ jobs:
           - { arch: amd64, ghc: 9.2.8 }
           - { arch: amd64, ghc: 9.4.7 }
           - { arch: amd64, ghc: 9.6.3 }
+          - { arch: amd64, ghc: 9.8.1 }
           - { arch: arm64, ghc: 9.2.8 }
           - { arch: arm64, ghc: 9.4.7 }
           - { arch: arm64, ghc: 9.6.3 }
+          - { arch: arm64, ghc: 9.8.1 }
     runs-on: ubuntu-latest
     steps:
 
@@ -37,6 +39,7 @@ jobs:
           - 9.2.8
           - 9.4.7
           - 9.6.3
+          - 9.8.1
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -6,11 +6,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { arch: amd64, ghc: 9.2.8 }
           - { arch: amd64, ghc: 9.4.7 }
           - { arch: amd64, ghc: 9.6.3 }
           - { arch: amd64, ghc: 9.8.1 }
-          - { arch: arm64, ghc: 9.2.8 }
           - { arch: arm64, ghc: 9.4.7 }
           - { arch: arm64, ghc: 9.6.3 }
           - { arch: arm64, ghc: 9.8.1 }
@@ -36,7 +34,6 @@ jobs:
     strategy:
       matrix:
         ghc:
-          - 9.2.8
           - 9.4.7
           - 9.6.3
           - 9.8.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN \
 
 # Install HLS.
 
-ARG HLS_VERSION=2.3.0.0
+ARG HLS_VERSION=2.4.0.0
 RUN \
   set -o errexit -o xtrace; \
   if test -n "$HLS_VERSION"; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN \
 
 # Install GHC.
 
-ARG GHC_VERSION=9.6.3
+ARG GHC_VERSION=9.8.1
 RUN \
   set -o errexit -o xtrace; \
   if test -n "$GHC_VERSION"; then \

--- a/aws/image.yaml
+++ b/aws/image.yaml
@@ -7,7 +7,7 @@ env:
     AWS_REGION: us-east-1
     # These values are simply the defaults. They are typically overriden by the
     # workflow in `.github/workflows/workflow.yaml`.
-    GHC_VERSION: 9.6.3
+    GHC_VERSION: 9.8.1
 phases:
   build:
     commands:

--- a/aws/manifest.yaml
+++ b/aws/manifest.yaml
@@ -4,7 +4,7 @@ env:
     AWS_REGION: us-east-1
     # These values are simply the defaults. They are typically overriden by
     # the workflow in `.github/workflows/workflow.yaml`.
-    GHC_VERSION: 9.6.3
+    GHC_VERSION: 9.8.1
     LATEST: 'false'
 phases:
   build:


### PR DESCRIPTION
Fixes #65.

- Also upgrade to HLS 2.4.0.0.
- Drop support for GHC 9.2.8. 

---

- [x] I manually tested the code locally to make sure that it works.
- [x] If there is documentation, I made sure it's accurate and up to date.
- [x] If possible, I wrote automated tests for the new behavior.
